### PR TITLE
chore(deps): group Dependabot updates for better management

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,10 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    groups:
+      golangci-lint:
+        patterns:
+          - "golangci*"
+      ci:
+        patterns:
+          - "*"


### PR DESCRIPTION
Add grouping to Dependabot configuration to separate golangci-lint
and CI-related dependency updates. This improves update clarity and
allows targeted review of dependency changes on a weekly schedule.