### PR TITLE
ci: simplify Go setup in GitHub Actions workflows

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -14,27 +14,17 @@ concurrency:
   group: ${{ format('{0}-{1}', github.workflow, github.head_ref) }}
   cancel-in-progress: true
 
-env:
-  GO: "1.24"
-
 permissions: read-all
 
 jobs:
   UnitTests:
     runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4.2.2 # immutable action, safe to use a version instead of hashtag
-
-      - name: Install Go
-        uses: actions/setup-go@v5.5.0 # immutable action, safe to use a version instead of hashtag
+      - uses: actions/checkout@v4.2.2 # immutable action, safe to use a version instead of hashtag
+      - uses: actions/setup-go@v5.5.0 # immutable action, safe to use a version instead of hashtag
         with:
-          go-version: ${{ env.GO }}
-
-      - name: Run Unit Tests
-        run: go test -race -cover -coverprofile=coverage.out -covermode=atomic
-
+          go-version-file: go.mod
+      - run: go test -race -cover -coverprofile=coverage.out -covermode=atomic
       - name: Codecov
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
         env:
@@ -42,17 +32,11 @@ jobs:
 
   GolangCI-Lint:
     runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4.2.2 # immutable action, safe to use a version instead of hashtag
-
-      - name: Install Go
-        uses: actions/setup-go@v5.5.0 # immutable action, safe to use a version instead of hashtag
+      - uses: actions/checkout@v4.2.2 # immutable action, safe to use a version instead of hashtag
+      - uses: actions/setup-go@v5.5.0 # immutable action, safe to use a version instead of hashtag
         with:
-          go-version: ${{ env.GO }}
-
-      - name: Run GolangCi-Lint
-        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
+          go-version-file: go.mod
+      - uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
           version: latest


### PR DESCRIPTION
Remove explicit GO environment variable and version pinning in the
checks workflow. Use go-version-file pointing to go.mod for setup-go
action to automatically detect the Go version. This reduces maintenance
overhead and ensures the Go version stays in sync with the project. Also,
streamline steps by removing redundant step names for checkout and setup-go.