### PR TITLE
chore: replace yaml parser with goccy/go-yaml for stricter decoding

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/sv-tools/mock-http-server
 go 1.24.0
 
 require (
+	github.com/goccy/go-yaml v1.17.1
 	github.com/spf13/pflag v1.0.6
 	golang.org/x/exp v0.0.0-20250506013437-ce4c2cf36ca6
-	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,6 @@
+github.com/goccy/go-yaml v1.17.1 h1:LI34wktB2xEE3ONG/2Ar54+/HJVBriAGJ55PHls4YuY=
+github.com/goccy/go-yaml v1.17.1/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
 github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
 github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 golang.org/x/exp v0.0.0-20250506013437-ce4c2cf36ca6 h1:y5zboxd6LQAqYIhHnB48p0ByQ/GnQx2BE33L8BOHQkI=
 golang.org/x/exp v0.0.0-20250506013437-ce4c2cf36ca6/go.mod h1:U6Lno4MTRCDY+Ba7aCcauB9T60gsv5s4ralQzP72ZoQ=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
-gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -11,9 +11,9 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/goccy/go-yaml"
 	flag "github.com/spf13/pflag"
 	"golang.org/x/exp/slog"
-	"gopkg.in/yaml.v3"
 )
 
 func main() {
@@ -41,8 +41,7 @@ func main() {
 	}
 
 	var config Config
-	d := yaml.NewDecoder(f)
-	d.KnownFields(true)
+	d := yaml.NewDecoder(f, yaml.DisallowUnknownField())
 	if err := d.Decode(&config); err != nil {
 		log.Error("decoding config failed", err)
 		os.Exit(1)


### PR DESCRIPTION
Switch from gopkg.in/yaml.v3 to github.com/goccy/go-yaml, due to yaml.v3 is deprecated