### PR TITLE
docs: improve README with docker usage instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 # vendor/
 
 .github/Brewfile.lock.json
+
+mock-http-server

--- a/README.md
+++ b/README.md
@@ -9,8 +9,16 @@ A simple HTTP Server to be used for the unit or end-to-end or integrations tests
 
 ## Usage
 
+Run docker image with the example config for the latest release:
 ```shell
 docker run -p 8080:8080 -v $(pwd)/example_config.yaml:/config.yaml -e CONFIG=config.yaml ghcr.io/sv-tools/mock-http-server:latest
+```
+
+Or build and run the docker image locally:
+```shell
+GOOS=linux GOARCH=amd64 go build
+docker build --tag mock-http-server:latest .
+docker run -p 8080:8080 -v $(pwd)/example_config.yaml:/config.yaml -e CONFIG=config.yaml mock-http-server:latest
 ```
 
 in second shell
@@ -22,6 +30,12 @@ curl http://localhost:8080/users/1 -H"X-Request-Id: 123"
 > {"id":1,"name":"John"}
 ```
 
+The first shell should produce the following log lines:
+```json
+{"time":"2025-05-20T21:30:14.551460052Z","level":"INFO","msg":"Listen on http://localhost:8080"}
+{"time":"2025-05-20T21:31:38.962693466Z","level":"INFO","msg":"request completed","http_scheme":"http","http_proto":"HTTP/1.1","http_method":"GET","remote_addr":"192.168.65.1:18659","user_agent":"curl/8.7.1","uri":"http://localhost:8080/users","resp_status":200,"resp_byte_length":85,"request_id":"123"}
+{"time":"2025-05-20T21:32:43.655666343Z","level":"INFO","msg":"request completed","http_scheme":"http","http_proto":"HTTP/1.1","http_method":"GET","remote_addr":"192.168.65.1:47480","user_agent":"curl/8.7.1","uri":"http://localhost:8080/users/1","resp_status":200,"resp_byte_length":34,"request_id":"123"}
+```
 
 ## License
 


### PR DESCRIPTION
Add detailed steps to run the mock-http-server using the latest
docker image or by building and running the image locally. Include
example commands for both approaches to simplify usage.

Also add example logs produced by the server to demonstrate expected
output and help users verify correct operation. These changes improve
the clarity and usability of the README for new users.