### PR TITLE
chore: update Go version to 1.24 in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sv-tools/mock-http-server
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/goccy/go-yaml v1.17.1


### PR DESCRIPTION
Simplify Go version specification by removing patch version
from 1.24.0 to 1.24. This aligns with Go module versioning
best practices and ensures compatibility with Go tooling.