### PR TITLE
ci: simplify release workflow and improve Go setup

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,9 +8,6 @@ on:
 permissions:
   contents: write
 
-env:
-  GO: "1.24"
-
 jobs:
   release-cli:
     if: github.event_name == 'push'
@@ -18,30 +15,23 @@ jobs:
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4.2.2 # immutable action, safe to use a version instead of hashtag
-
-      - name: Install Go
-        uses: actions/setup-go@v5.5.0 # immutable action, safe to use a version instead of hashtag
+      - uses: actions/checkout@v4.2.2 # immutable action, safe to use a version instead of hashtag
+      - uses: actions/setup-go@v5.5.0 # immutable action, safe to use a version instead of hashtag
         with:
-          go-version: ${{ env.GO }}
-
+          go-version-file: go.mod
       - name: Allow arm Docker builds # https://github.com/linuxkit/linuxkit/tree/master/pkg/binfmt
         run: sudo docker run --privileged linuxkit/binfmt:v0.8
-
       - name: Docker Login
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: ghcr.io
           username: sv-tools-bot
           password: ${{ secrets.BOT_TOKEN }}
-
       - name: Docker Login
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           username: svtools
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
-
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 # v6.3.0
         with:


### PR DESCRIPTION
Remove the global GO environment variable and streamline the release
workflow by specifying the Go version directly from go.mod in the
setup-go action. This reduces duplication and potential version drift.

Also, clean up unnecessary steps and comments to make the workflow
more concise and maintainable.