### PR TITLE
ci: update release workflow and Goreleaser config

### DIFF
--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -1,3 +1,5 @@
+version: 2
+
 project_name: mock-http-server
 
 release:
@@ -20,7 +22,8 @@ builds:
     ldflags: -s -w -X main.version={{ .Tag }}
 
 archives:
-  - format: tar.gz
+  - formats:
+      - tar.gz
     wrap_in_directory: true
     name_template: "{{ .Binary }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}"
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,15 +12,12 @@ jobs:
   release-cli:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
-    env:
-      DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:
       - uses: actions/checkout@v4.2.2 # immutable action, safe to use a version instead of hashtag
       - uses: actions/setup-go@v5.5.0 # immutable action, safe to use a version instead of hashtag
         with:
           go-version-file: go.mod
-      - name: Allow arm Docker builds # https://github.com/linuxkit/linuxkit/tree/master/pkg/binfmt
-        run: sudo docker run --privileged linuxkit/binfmt:v0.8
+      - uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # 3.10.0
       - name: Docker Login
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
@@ -36,7 +33,7 @@ jobs:
         uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 # v6.3.0
         with:
           version: latest
-          args: release --config .github/goreleaser-cli.yml
+          args: release --config .github/goreleaser.yaml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Replace manual Docker setup with docker/setup-buildx-action to enable
multi-platform builds in the release workflow. Remove deprecated
DOCKER_CLI_EXPERIMENTAL environment variable. Fix Goreleaser config file
reference and update its format to version 2 with corrected archive
formats. These changes improve build reliability and maintainability.