### PR TITLE
chore(de): replace x/ slog with std slog

### DIFF
--- a/config.go
+++ b/config.go
@@ -3,11 +3,10 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"os"
 	"text/template"
-
-	"golang.org/x/exp/slog"
 )
 
 type Config struct {

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,8 @@
 module github.com/sv-tools/mock-http-server
 
-go 1.24
+go 1.25
 
 require (
 	github.com/goccy/go-yaml v1.18.0
 	github.com/spf13/pflag v1.0.7
-	golang.org/x/exp v0.0.0-20250506013437-ce4c2cf36ca6
 )

--- a/go.sum
+++ b/go.sum
@@ -2,5 +2,3 @@ github.com/goccy/go-yaml v1.18.0 h1:8W7wMFS12Pcas7KU+VVkaiCng+kG8QiFeFwzFb+rwuw=
 github.com/goccy/go-yaml v1.18.0/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
 github.com/spf13/pflag v1.0.7 h1:vN6T9TfwStFPFM5XzjsvmzZkLuaLX+HS+0SeFLRgU6M=
 github.com/spf13/pflag v1.0.7/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
-golang.org/x/exp v0.0.0-20250506013437-ce4c2cf36ca6 h1:y5zboxd6LQAqYIhHnB48p0ByQ/GnQx2BE33L8BOHQkI=
-golang.org/x/exp v0.0.0-20250506013437-ce4c2cf36ca6/go.mod h1:U6Lno4MTRCDY+Ba7aCcauB9T60gsv5s4ralQzP72ZoQ=

--- a/log.go
+++ b/log.go
@@ -2,9 +2,8 @@ package main
 
 import (
 	"fmt"
+	"log/slog"
 	"net/http"
-
-	"golang.org/x/exp/slog"
 )
 
 type wrapper struct {


### PR DESCRIPTION
Update logging to use the new standard library slog package
instead of golang.org/x/exp/slog. Replace imports across
config.go, main.go, log.go to import "log/slog" and remove the
x/exp dependency from go.mod and go.sum. Also bump go toolchain
version to 1.25 and fix a minor comment wording ("a grace period").
These changes simplify dependencies and adopt the stable slog
implementation from the standard library.