### PR TITLE
chore(deps): replace goccy/go-yaml with go.yaml.in/yaml v4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,6 @@ module github.com/sv-tools/mock-http-server
 
 go 1.25
 
-require (
-	github.com/goccy/go-yaml v1.18.0
-	github.com/spf13/pflag v1.0.10
-)
+require github.com/spf13/pflag v1.0.10
+
+require go.yaml.in/yaml/v4 v4.0.0-rc.2

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/goccy/go-yaml v1.18.0 h1:8W7wMFS12Pcas7KU+VVkaiCng+kG8QiFeFwzFb+rwuw=
-github.com/goccy/go-yaml v1.18.0/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+go.yaml.in/yaml/v4 v4.0.0-rc.2 h1:/FrI8D64VSr4HtGIlUtlFMGsm7H7pWTbj6vOLVZcA6s=
+go.yaml.in/yaml/v4 v4.0.0-rc.2/go.mod h1:aZqd9kCMsGL7AuUv/m/PvWLdg5sjJsZ4oHDEnfPPfY0=

--- a/main.go
+++ b/main.go
@@ -12,8 +12,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/goccy/go-yaml"
 	flag "github.com/spf13/pflag"
+	"go.yaml.in/yaml/v4"
 )
 
 func main() {
@@ -41,7 +41,8 @@ func main() {
 	}
 
 	var config Config
-	d := yaml.NewDecoder(f, yaml.DisallowUnknownField())
+	d := yaml.NewDecoder(f)
+	d.KnownFields(true)
 	if err := d.Decode(&config); err != nil {
 		log.Error("decoding config failed", slog.String("error", err.Error()))
 		os.Exit(1)


### PR DESCRIPTION
Switch dependency from github.com/goccy/go-yaml v1.18.0 to the new
module path go.yaml.in/yaml v4.0.0-rc.2 and update imports accordingly.

- Simplify go.mod by using a direct require line for spf13/pflag and adding
  the new go.yaml.in/yaml v4 prerelease.
- Update main.go imports to use go.yaml.in/yaml/v4 instead of the old
  github.com/goccy/go-yaml import.
- Refresh go.sum entries to remove the goccy/go-yaml checksums and add
  checksums for go.yaml.in/yaml v4.0.0-rc.2.

These changes prepare the codebase for the v4 YAML API and resolve
module path differences to ensure correct module resolution.